### PR TITLE
[APIDX-798] Setup automatic publishing to MavenCentral

### DIFF
--- a/.github/workflows/publish_sdk.yaml
+++ b/.github/workflows/publish_sdk.yaml
@@ -8,12 +8,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Genereate
+      - name: Publish SDKs
+        env:
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          MAVEN_SECRING_GPG_BASE64: ${{ secrets.MAVEN_SECRING_GPG_BASE64 }}
+          MAVEN_SECRING_PASSWORD: ${{ secrets.MAVEN_SECRING_PASSWORD }}
         run: |
           chmod +x ./scripts/publish_sdk.sh
           ./scripts/publish_sdk.sh
         shell: bash
-    
+
       - name: Send success notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/scripts/publish_sdk.sh
+++ b/scripts/publish_sdk.sh
@@ -1,2 +1,31 @@
-echo "Publihsing SDK..."
-echo "Done."
+echo "Looping through generated Java SDKs..."
+
+DID_FAIL=false
+
+for dir in ./sdks/*;
+    do (
+        if [ -d "$dir" ];
+            then
+                echo "$dir"
+                cd "$dir"
+                echo "Publishing this SDK to Maven Central."
+                chmod +x gradlew
+                ./gradlew publishToSonatype closeSonatypeStagingRepository; gradlew_return_code=$?
+                # TODO - When ready to have the process fully automated, delete the line above and uncomment out the line below.
+                # The current script will push the SDKs to the Nexus Repository Manager, but will not publish them to MavenCentral.
+                # ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository; gradlew_return_code=$?
+                if (( gradlew_return_code !=0 )); then
+                    echo "Publication failed"
+                    DID_FAIL=true
+                fi
+        fi
+    );
+done
+
+if [ "$DID_FAIL" = true ]
+then
+    echo "At least one SDK failed to publish."
+    exit 1
+fi
+
+echo "SDKs were published successfully."


### PR DESCRIPTION
This commit prepares for the the automatic publishing of Java SDKs to MavenCentral. For now, they will only be pushed to the Nexus Repository. Follow the instructions in the publish_sdk.sh to turn on automatic publishing.