### PR TITLE
🐛 Fix publish_sdk.sh to report generation failure.

### DIFF
--- a/scripts/publish_sdk.sh
+++ b/scripts/publish_sdk.sh
@@ -3,7 +3,7 @@ echo "Looping through generated Java SDKs..."
 DID_FAIL=false
 
 for dir in ./sdks/*;
-    do (
+    do
         if [ -d "$dir" ];
             then
                 echo "$dir"
@@ -18,7 +18,6 @@ for dir in ./sdks/*;
                     DID_FAIL=true
                 fi
         fi
-    );
 done
 
 if [[ $DID_FAIL == true ]]


### PR DESCRIPTION
Removing the parenthesis allow the global DID_FAIL variable to be correctly updated by the loop.